### PR TITLE
crossbrowser selector

### DIFF
--- a/lib/isDomSelector.js
+++ b/lib/isDomSelector.js
@@ -1,10 +1,29 @@
 function isDomSelector (str) {
   try {
-    document.querySelector(str)
-    return true
+    if (document.querySelector) {
+      return Boolean(document.querySelector(str))
+    }
+
+    if (isDomElement(document.getElementsByTagName(str))) {
+      return true
+    }
+
+    if (isDomElement(document.getElementsByClassName(str))) {
+      return true
+    }
+
+    if (isDomElement(document.getElementById(str))) {
+      return true
+    }
+
+    return false
   } catch (error) {
     return false
   }
-}
+};
+
+function isDomElement (element) {
+  return element && element.length
+};
 
 module.exports = isDomSelector


### PR DESCRIPTION
"document.querySelector" is not supported by old browsers (IE8 and lower as example)